### PR TITLE
正确处理items数量变少的情况（比如刷新列表）

### DIFF
--- a/src/Waterfall.js
+++ b/src/Waterfall.js
@@ -104,6 +104,9 @@ class Waterfall extends React.Component {
 
   setChildSize({index, height, width}) {
     const { items } = this.props
+    if(index===0){
+      this.childrenSizes = {};
+    }
     this.childrenSizes = Object.assign({} , this.childrenSizes, {
       [index]: {
         width,


### PR DESCRIPTION
当组件的items变少时，高度会保持不变。
加了一句代码解决这个问题。